### PR TITLE
Fixing typo in alternate install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ following steps (create/adapt first the directory
     cd my-coursera
     source bin/activate
     git clone https://github.com/coursera-dl/coursera-dl
-    cd coursera
+    cd coursera-dl
     pip install -r requirements.txt
     ./coursera-dl ...
 


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.
## Proposed changes

When running the alternative install instructions, it says `cd coursera`, but that isn't the directory which you have when you clone the repo.  This needs to be `cd coursera-dl`.
## Types of changes

What types of changes does your code introduce?

Just a readme update.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist
- [ x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [ ] I have checked that the unit tests pass locally with my changes
- [ ] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
## Further comments

None
### Reviewers
